### PR TITLE
Revert skip chromatic publish in action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,11 +37,11 @@ jobs:
     - name: Test
       run: npm test -- --ci
 
-    # - name: Publish to Chromatic
-    #   uses: chromaui/action@v1
-    #   with:
-    #     token: ${{ secrets.VITALIY_GITHUB_TOKEN }}
-    #     projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+    - name: Publish to Chromatic
+      uses: chromaui/action@v1
+      with:
+        token: ${{ secrets.VITALIY_GITHUB_TOKEN }}
+        projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
 
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Waiting for resolving this issue: https://github.com/chromaui/chromatic-cli/issues/273

Co-authored-by: Evgeniy Hinyuk <myacheg@gmail.com>

This reverts commit 9126b9dee3078d6042df31c970cb095764b69fee, reversing
changes made to 161214f633ed22877a4e76b92812a80a21c209ff.